### PR TITLE
Update cancer types for DEA

### DIFF
--- a/data/in/config/DEA_queries/dea_queries.json
+++ b/data/in/config/DEA_queries/dea_queries.json
@@ -17,10 +17,18 @@
     },
     "Cervix_cancer": {
         "case": [
-            "<meta>@sample?_study=TCGA&_primary_site=[Cervix,Cervix Uteri,Vagina]&_sample_type!=[Solid Tissue Normal,Control Analyte]"
+            "<meta>@sample?_study=TCGA&_primary_site=[Cervix,Cervix Uteri]&_sample_type!=[Solid Tissue Normal,Control Analyte]"
         ],
         "control": [
-            "<meta>@sample?_study=[TCGA,GTEX]&_primary_site=[Cervix,Cervix Uteri,Vagina]&_sample_type=[Normal Tissue,Solid Tissue Normal]"
+            "<meta>@sample?_study=[TCGA,GTEX]&_primary_site=[Cervix,Cervix Uteri]&_sample_type=[Normal Tissue,Solid Tissue Normal]"
+        ]
+    },
+    "Vaginal_cancer": {
+        "case": [
+            "<meta>@sample?_study=TCGA&_primary_site=[Vagina]&_sample_type!=[Solid Tissue Normal,Control Analyte]"
+        ],
+        "control": [
+            "<meta>@sample?_study=[TCGA,GTEX]&_primary_site=[Vagina]&_sample_type=[Normal Tissue,Solid Tissue Normal]"
         ]
     },
     "Uterine_cancer": {
@@ -111,12 +119,20 @@
             "<meta>@sample?_study=[TCGA,GTEX]&_primary_site=[Thyroid Gland,Thyroid]&_sample_type=[Normal Tissue,Solid Tissue Normal]"
         ]
     },
-    "Lymphoma": {
+    "blood_cancer": {
         "case": [
-            "<meta>@sample?_study=TCGA&_primary_site=[Blood,White blood cell,Bone Marrow]&_sample_type!=[Solid Tissue Normal,Control Analyte]"
+            "<meta>@sample?_study=TCGA&_primary_site=[Blood,White blood cell]&_sample_type!=[Solid Tissue Normal,Control Analyte]"
         ],
         "control": [
-            "<meta>@sample?_study=[TCGA,GTEX]&_primary_site=[Blood,White blood cell,Bone Marrow]&_sample_type=[Normal Tissue,Solid Tissue Normal]"
+            "<meta>@sample?_study=[TCGA,GTEX]&_primary_site=[Blood,White blood cell]&_sample_type=[Normal Tissue,Solid Tissue Normal]"
+        ]
+    },
+    "bone_marrow_cancer": {
+        "case": [
+            "<meta>@sample?_study=TCGA&_primary_site=[Bone Marrow]&_sample_type!=[Solid Tissue Normal,Control Analyte]"
+        ],
+        "control": [
+            "<meta>@sample?_study=[TCGA,GTEX]&_primary_site=[Bone Marrow]&_sample_type=[Normal Tissue,Solid Tissue Normal]"
         ]
     },
     "Kidney_cancer": {
@@ -135,7 +151,7 @@
             "<meta>@sample?_study=[TCGA,GTEX]&_primary_site=Bladder&_sample_type=[Normal Tissue,Solid Tissue Normal]"
         ]
     },
-    "Pancreas_cancer": {
+    "Pancreatic_cancer": {
         "case": [
             "<meta>@sample?_study=TCGA&_primary_site=Pancreas&_sample_type!=[Solid Tissue Normal,Control Analyte]"
         ],


### PR DESCRIPTION
I've split the most painful points of the DEA definitions:
- Added a new `vaginal_cancer` category by splitting vagina from the cervical cancers;
- Added a new `bone_marrow_cancer` category by splitting "bone marrow" from the lymphoma category;
- Renamed "lymphoma" to the more generic "blood_cancer" (I'm pretty sure there are no blood cancers other than lymphoma, but I'm not 100% sure at this point)